### PR TITLE
Fix when using RedisCache with byte array

### DIFF
--- a/IntelligentCache/RedisCache.cs
+++ b/IntelligentCache/RedisCache.cs
@@ -42,7 +42,7 @@ namespace IntelligentHack.IntelligentCache
                 return res;
             }
 
-            return Serializer.Deserialize<T>(value.ToString());
+            return Serializer.Deserialize<T>(value);
         }
 
         public async Task InvalidateAsync(string key, CancellationToken cancellationToken = default)
@@ -65,7 +65,7 @@ namespace IntelligentHack.IntelligentCache
                 return res;
             }
 
-            return Serializer.Deserialize<T>(value.ToString());
+            return Serializer.Deserialize<T>(value);
         }
 
         public void Invalidate(string key)


### PR DESCRIPTION
When we store a byte array to redis using RedisCache the value pass to Deserialize is not the real value because ToString on RedisValue change the value